### PR TITLE
Python source was missing from PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,12 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Miker2808/PyRoboteq",
-    packages=['pyserial'],
+    packages=['PyRoboteq'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
+    requires='pyserial'
 )


### PR DESCRIPTION
After running a pip install, I noticed that I was unable to import the PyRoboteq class.
As a result, the package isn't usable in its current state. I edited the setup.py which hopefully fixes the issue.